### PR TITLE
Default to select command

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ In short, the output files may have properties in a different order but the actu
 dasel -h
 ```
 
+An imortant note is that if no sub-command is given, dasel will default to `select`.
+
 ### Select
 ```bash
 dasel select -f <file> -p <json|yaml|toml> <selector>
@@ -325,7 +327,7 @@ The follow examples show a set of [jq](https://github.com/stedolan/jq) commands 
 echo '{"name": "Tom"}' | jq '.name'
 "Tom"
 
-echo '{"name": "Tom"}' | dasel select -p json -s '.name'
+echo '{"name": "Tom"}' | dasel -p json '.name'
 Tom
 ```
 
@@ -335,7 +337,7 @@ Tom
 echo '{"user": {"name": "Tom", "age": 27}}' | jq '.user.age'
 27
 
-echo '{"user": {"name": "Tom", "age": 27}}' | dasel select -p json -s '.user.age'
+echo '{"user": {"name": "Tom", "age": 27}}' | dasel -p json '.user.age'
 27
 ```
 
@@ -345,7 +347,7 @@ echo '{"user": {"name": "Tom", "age": 27}}' | dasel select -p json -s '.user.age
 echo '[1, 2, 3]' | jq '.[1]'
 2
 
-echo '[1, 2, 3]' | dasel select -p json -s '.[1]'
+echo '[1, 2, 3]' | dasel -p json '.[1]'
 2
 ```
 
@@ -463,7 +465,7 @@ The follow examples show a set of [yq](https://github.com/kislyuk/yq) commands a
 echo 'name: Tom' | yq '.name'
 "Tom"
 
-echo 'name: Tom' | dasel select -p yaml -s '.name'
+echo 'name: Tom' | dasel -p yaml '.name'
 Tom
 ```
 
@@ -477,7 +479,7 @@ echo 'user:
 
 echo 'user:
        name: Tom
-       age: 27' | dasel select -p yaml -s '.user.age'
+       age: 27' | dasel -p yaml '.user.age'
 27
 ```
 
@@ -491,7 +493,7 @@ echo '- 1
 
 echo '- 1
 - 2
-- 3' | dasel select -p yaml -s '.[1]'
+- 3' | dasel -p yaml '.[1]'
 2
 ```
 

--- a/cmd/dasel/main.go
+++ b/cmd/dasel/main.go
@@ -8,6 +8,7 @@ import (
 
 func main() {
 	cmd := command.NewRootCMD()
+	command.ChangeDefaultCommand(cmd, "select", "-v", "--version", "help")
 	if err := cmd.Execute(); err != nil {
 		fmt.Println("Error: " + err.Error())
 		os.Exit(1)

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -3,7 +3,13 @@ package command
 import (
 	"github.com/spf13/cobra"
 	"github.com/tomwright/dasel/internal"
+	"os"
 )
+
+type Command struct {
+	cobra.Command
+	DefaultSubCommand string
+}
 
 // NewRootCMD returns the root command for use with cobra.
 func NewRootCMD() *cobra.Command {
@@ -17,4 +23,34 @@ func NewRootCMD() *cobra.Command {
 		putCommand(),
 	)
 	return cmd
+}
+
+// ChangeDefaultCommand checks to see if the current os.Args target a valid subcommand.
+// If they do not they are adjusted to target the given command.
+// If any of the blacklisted args are set in os.Args, no action is taken.
+func ChangeDefaultCommand(cmd *cobra.Command, command string, blacklistedArgs ...string) {
+	subCommands := func() []string {
+		results := make([]string, 0)
+		for _, subCmd := range cmd.Commands() {
+			results = append(results, append(subCmd.Aliases, subCmd.Name())...)
+		}
+		return results
+	}
+
+	if len(os.Args) > 1 {
+		potentialCommand := os.Args[1]
+		for _, command := range subCommands() {
+			if command == potentialCommand {
+				return
+			}
+		}
+		for _, arg := range os.Args {
+			for _, blacklistedArg := range blacklistedArgs {
+				if arg == blacklistedArg {
+					return
+				}
+			}
+		}
+		os.Args = append([]string{os.Args[0], command}, os.Args[1:]...)
+	}
 }

--- a/internal/command/root_test.go
+++ b/internal/command/root_test.go
@@ -3,9 +3,57 @@ package command_test
 import (
 	"bytes"
 	"github.com/tomwright/dasel/internal/command"
+	"os"
+	"reflect"
 	"strings"
 	"testing"
 )
+
+func TestChangeDefaultCommand(t *testing.T) {
+	cachedArgs := os.Args
+	defer func() {
+		os.Args = cachedArgs
+	}()
+
+	t.Run("ChangeToSelect", func(t *testing.T) {
+		os.Args = []string{"dasel", "-p", "json", ".name"}
+		exp := []string{"dasel", "select", "-p", "json", ".name"}
+
+		cmd := command.NewRootCMD()
+		command.ChangeDefaultCommand(cmd, "select")
+
+		got := os.Args
+		if !reflect.DeepEqual(exp, got) {
+			t.Errorf("expected args %v, got %v", exp, got)
+		}
+	})
+
+	t.Run("AlreadySelect", func(t *testing.T) {
+		os.Args = []string{"dasel", "select", "-p", "json", ".name"}
+		exp := []string{"dasel", "select", "-p", "json", ".name"}
+
+		cmd := command.NewRootCMD()
+		command.ChangeDefaultCommand(cmd, "select")
+
+		got := os.Args
+		if !reflect.DeepEqual(exp, got) {
+			t.Errorf("expected args %v, got %v", exp, got)
+		}
+	})
+
+	t.Run("AlreadyPut", func(t *testing.T) {
+		os.Args = []string{"dasel", "put", "-p", "json", "-t", "string", "name=Tom"}
+		exp := []string{"dasel", "put", "-p", "json", "-t", "string", "name=Tom"}
+
+		cmd := command.NewRootCMD()
+		command.ChangeDefaultCommand(cmd, "select")
+
+		got := os.Args
+		if !reflect.DeepEqual(exp, got) {
+			t.Errorf("expected args %v, got %v", exp, got)
+		}
+	})
+}
 
 func TestRootCMD(t *testing.T) {
 	t.Run("Select", func(t *testing.T) {


### PR DESCRIPTION
Closes #9 

Adjust `os.Args` to target the select command by default if another command was not targeted.
