### PR TITLE
Add put document support and fix some issues:

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,8 +558,6 @@ You are able to put entire documents using `put document`.
 dasel put document -f <file> -o <out> -p <parser> -m <selector> -d <document-parser> <document>
 ```
 
-If you want to create an empty object just omit the type flag and the values.
-
 #### Arguments
 
 ##### `-f`, `--file`
@@ -574,7 +572,7 @@ Specify the output file. If present, results will be written to the given file. 
 
 To force output to be written to stdout, pass `-o stdout`/`-o -`.
 
-##### `-d`, `--document-parser`
+##### `-d`, `--document-parser`, `<document-parser>`
 
 Specify the parser to use when reading the document value.
 
@@ -608,20 +606,6 @@ Tells dasel to put multiple items.
 
 This causes the [dynamic](#dynamic) selector to return all matching results rather than the first, and enables the [any index](#any-index) selector.
 
-E.g.
-
-```
-echo '[{"name": "Tom"}, {"name": "Jim"}]' | dasel put object -p json -m -t string '.[*]' 'name=Frank'
-[
-  {
-    "name": "Frank"
-  },
-  {
-    "name": "Frank"
-  }
-]
-```
-
 ##### `-s`, `--selector`, `<selector>`
 
 Specify the selector to use. See [Selectors](#selectors) for more information.
@@ -630,9 +614,11 @@ If no selector flag is given, dasel assumes the first argument given is the sele
 
 This is required.
 
-##### `document`
+##### `document`, `<document>`
 
 The document you want to put, as a string.
+
+This is required.
 
 #### Example
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ Dasel uses a standard selector syntax no matter the data format. This means that
   * [Select](#select)
   * [Put](#put)
   * [Put Object](#put-object)
+  * [Put Document](#put-document)
 * [Supported file types](#supported-file-types)
   * [JSON](#json)
   * [TOML](#toml)
@@ -549,6 +550,116 @@ my:
     number: 3
 ```
 
+### Put Document
+
+You are able to put entire documents using `put document`.
+
+```bash
+dasel put document -f <file> -o <out> -p <parser> -m <selector> -d <document-parser> <document>
+```
+
+If you want to create an empty object just omit the type flag and the values.
+
+#### Arguments
+
+##### `-f`, `--file`
+
+Specify the file to query. This is required unless you are piping in data.
+
+If piping in data you can optionally pass `-f stdin`/`-f -`.
+
+##### `-o`, `--out`
+
+Specify the output file. If present, results will be written to the given file. If not present, results will be written to the input file (or stdout if none given).
+
+To force output to be written to stdout, pass `-o stdout`/`-o -`.
+
+##### `-d`, `--document-parser`
+
+Specify the parser to use when reading the document value.
+
+If no value is provided, the read parser is used.
+
+See [supported parsers](#supported-file-types).
+
+##### `-r`, `--read`
+
+Specify the parser to use when reading the input data.
+
+This is required if you are piping in data, otherwise dasel will use the given file extension to guess which parser to use.
+
+See [supported parsers](#supported-file-types).
+
+##### `-w`, `--write`
+
+Specify the parser to use when writing the output data.
+
+If not provided dasel will attempt to use the `--out` and `--read` flags to determine which parser to use.
+
+See [supported parsers](#supported-file-types).
+
+##### `-p`, `--parser`
+
+Shorthand for `-r <value> -w <value>`
+
+##### `-m`, `--multiple`
+
+Tells dasel to put multiple items.
+
+This causes the [dynamic](#dynamic) selector to return all matching results rather than the first, and enables the [any index](#any-index) selector.
+
+E.g.
+
+```
+echo '[{"name": "Tom"}, {"name": "Jim"}]' | dasel put object -p json -m -t string '.[*]' 'name=Frank'
+[
+  {
+    "name": "Frank"
+  },
+  {
+    "name": "Frank"
+  }
+]
+```
+
+##### `-s`, `--selector`, `<selector>`
+
+Specify the selector to use. See [Selectors](#selectors) for more information.
+
+If no selector flag is given, dasel assumes the first argument given is the selector.
+
+This is required.
+
+##### `document`
+
+The document you want to put, as a string.
+
+#### Example
+
+```bash
+echo '{"people":[]}' | dasel put document -p json -d yaml '.people.[]' 'name: Tom
+colours:
+- red
+- green
+- blue'
+```
+
+Results in the following:
+```json
+{
+  "people": [
+    {
+      "colours": [
+        "red",
+        "green",
+        "blue"
+      ],
+      "name": "Tom"
+    }
+  ]
+}
+```
+
 ## Supported file types
 Dasel attempts to find the correct parser for the given file type, but if that fails you can choose which parser to use with the `-p` or `--parser` flag. 
 
@@ -980,7 +1091,7 @@ echo '{"users": [{"name": "Tom"}]}' | jq '.users += [{"name": "Frank"}]'
   ]
 }
 
-echo '{"users": [{"name": "Tom"}]}' | dasel put object -p json -s '.users[]' -t string name=Frank
+echo '{"users": [{"name": "Tom"}]}' | dasel put object -p json -s '.users.[]' -t string name=Frank
 {
   "users": [
     {
@@ -1122,7 +1233,7 @@ users:
 
 
 echo 'users:
-- name: Tom' | dasel put object -p yaml -s '.users[]' -t string name=Frank
+- name: Tom' | dasel put object -p yaml -s '.users.[]' -t string name=Frank
 users:
 - name: Tom
 - name: Frank

--- a/internal/command/put.go
+++ b/internal/command/put.go
@@ -272,6 +272,7 @@ func putCommand() *cobra.Command {
 		putBoolCommand(),
 		putIntCommand(),
 		putObjectCommand(),
+		putDocumentCommand(),
 	)
 
 	cmd.PersistentFlags().StringVarP(&fileFlag, "file", "f", "", "The file to query.")

--- a/internal/command/put_bool.go
+++ b/internal/command/put_bool.go
@@ -7,7 +7,7 @@ import (
 func putBoolCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "bool -f <file> -s <selector> <value>",
-		Short: "Update a bool property in the given file.",
+		Short: "Update a bool property in the given document.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGenericPutCommand(genericPutOptions{

--- a/internal/command/put_document_internal.go
+++ b/internal/command/put_document_internal.go
@@ -1,0 +1,119 @@
+package command
+
+import (
+	"fmt"
+	"github.com/spf13/cobra"
+	"github.com/tomwright/dasel/internal/storage"
+	"io"
+)
+
+type putDocumentOpts struct {
+	File           string
+	Out            string
+	ReadParser     string
+	WriteParser    string
+	Parser         string
+	Selector       string
+	DocumentString string
+	DocumentParser string
+	Reader         io.Reader
+	Writer         io.Writer
+	Multi          bool
+}
+
+func runPutDocumentCommand(opts putDocumentOpts, cmd *cobra.Command) error {
+	readParser, err := getReadParser(opts.File, opts.ReadParser, opts.Parser)
+	if err != nil {
+		return err
+	}
+	rootNode, err := getRootNode(getRootNodeOpts{
+		File:   opts.File,
+		Parser: readParser,
+		Reader: opts.Reader,
+	}, cmd)
+	if err != nil {
+		return err
+	}
+
+	documentParser, err := getPutDocumentParser(readParser, opts.DocumentParser)
+	if err != nil {
+		return err
+	}
+
+	documentValue, err := documentParser.FromBytes([]byte(opts.DocumentString))
+	if err != nil {
+		return fmt.Errorf("could not parse document: %w", err)
+	}
+
+	if opts.Multi {
+		if err := rootNode.PutMultiple(opts.Selector, documentValue); err != nil {
+			return fmt.Errorf("could not put document multi value: %w", err)
+		}
+	} else {
+		if err := rootNode.Put(opts.Selector, documentValue); err != nil {
+			return fmt.Errorf("could not put document value: %w", err)
+		}
+	}
+
+	writeParser, err := getWriteParser(readParser, opts.WriteParser, opts.Parser, opts.Out, opts.File)
+	if err != nil {
+		return err
+	}
+
+	if err := writeNodeToOutput(writeNodeToOutputOpts{
+		Node:   rootNode,
+		Parser: writeParser,
+		File:   opts.File,
+		Out:    opts.Out,
+		Writer: opts.Writer,
+	}, cmd); err != nil {
+		return fmt.Errorf("could not write output: %w", err)
+	}
+
+	return nil
+}
+
+func putDocumentCommand() *cobra.Command {
+	var documentParserFlag string
+
+	cmd := &cobra.Command{
+		Use:   "document -f <file> -d <document-parser> -s <selector> <document>",
+		Short: "Put an entire document into the given document.",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			opts := putDocumentOpts{
+				File:           cmd.Flag("file").Value.String(),
+				Out:            cmd.Flag("out").Value.String(),
+				ReadParser:     cmd.Flag("read").Value.String(),
+				WriteParser:    cmd.Flag("write").Value.String(),
+				Parser:         cmd.Flag("parser").Value.String(),
+				Selector:       cmd.Flag("selector").Value.String(),
+				DocumentParser: documentParserFlag,
+				DocumentString: args[0],
+			}
+			opts.Multi, _ = cmd.Flags().GetBool("multiple")
+
+			if opts.Selector == "" && len(args) > 1 {
+				opts.Selector = args[0]
+				opts.DocumentString = args[1]
+			}
+			return runPutDocumentCommand(opts, cmd)
+		},
+	}
+
+	cmd.Flags().StringVarP(&documentParserFlag, "document-parser", "d", "", "The parser to use when reading the document")
+
+	return cmd
+}
+
+func getPutDocumentParser(readParser storage.ReadParser, documentParserFlag string) (storage.ReadParser, error) {
+	if documentParserFlag == "" {
+		return readParser, nil
+	}
+
+	parser, err := storage.NewReadParserFromString(documentParserFlag)
+	if err != nil {
+		return nil, fmt.Errorf("could not get document parser: %w", err)
+	}
+	return parser, nil
+}

--- a/internal/command/put_document_internal_test.go
+++ b/internal/command/put_document_internal_test.go
@@ -1,0 +1,56 @@
+package command
+
+import (
+	"errors"
+	"github.com/tomwright/dasel/internal/storage"
+	"strings"
+	"testing"
+)
+
+func TestPut_Document(t *testing.T) {
+	t.Run("SingleFailingWriter", func(t *testing.T) {
+		err := runPutDocumentCommand(putDocumentOpts{
+			Parser:         "json",
+			Selector:       ".[0]",
+			Reader:         strings.NewReader(`[{"name": "Tom"}]`),
+			DocumentString: `{"name": "Frank"}`,
+			Writer:         &failingWriter{},
+		}, nil)
+
+		if err == nil || !errors.Is(err, errFailingWriterErr) {
+			t.Errorf("expected error %v, got %v", errFailingWriterErr, err)
+			return
+		}
+	})
+	t.Run("MultiFailingWriter", func(t *testing.T) {
+		err := runPutDocumentCommand(putDocumentOpts{
+			Parser:         "json",
+			Selector:       ".[*]",
+			Reader:         strings.NewReader(`[{"name": "Tom"}]`),
+			DocumentString: `{"name": "Frank"}`,
+			Writer:         &failingWriter{},
+			Multi:          true,
+		}, nil)
+
+		if err == nil || !errors.Is(err, errFailingWriterErr) {
+			t.Errorf("expected error %v, got %v", errFailingWriterErr, err)
+			return
+		}
+	})
+	t.Run("InvalidDocumentParser", func(t *testing.T) {
+		err := runPutDocumentCommand(putDocumentOpts{
+			Parser:         "json",
+			Selector:       ".[*]",
+			Reader:         strings.NewReader(`[{"name": "Tom"}]`),
+			DocumentString: `{"name": "Frank"}`,
+			DocumentParser: "bad",
+		}, nil)
+
+		exp := &storage.UnknownParserErr{Parser: "bad"}
+
+		if err == nil || !strings.HasSuffix(err.Error(), exp.Error()) {
+			t.Errorf("expected error %v, got %v", exp, err)
+			return
+		}
+	})
+}

--- a/internal/command/put_int.go
+++ b/internal/command/put_int.go
@@ -7,7 +7,7 @@ import (
 func putIntCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "int -f <file> -s <selector> <value>",
-		Short: "Update an int property in the given file.",
+		Short: "Update an int property in the given document.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGenericPutCommand(genericPutOptions{

--- a/internal/command/put_object_internal.go
+++ b/internal/command/put_object_internal.go
@@ -95,12 +95,14 @@ func putObjectCommand() *cobra.Command {
 
 	cmd := &cobra.Command{
 		Use:   "object -f <file> -s <selector> <value>",
-		Short: "Update a string property in the given file.",
+		Short: "Put an object in the given document.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			opts := putObjectOpts{
 				File:        cmd.Flag("file").Value.String(),
 				Out:         cmd.Flag("out").Value.String(),
+				ReadParser:  cmd.Flag("read").Value.String(),
+				WriteParser: cmd.Flag("write").Value.String(),
 				Parser:      cmd.Flag("parser").Value.String(),
 				Selector:    cmd.Flag("selector").Value.String(),
 				InputTypes:  typeList.Strings,

--- a/internal/command/put_string.go
+++ b/internal/command/put_string.go
@@ -7,7 +7,7 @@ import (
 func putStringCommand() *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "string -f <file> -s <selector> <value>",
-		Short: "Update a string property in the given file.",
+		Short: "Update a string property in the given document.",
 		Args:  cobra.MinimumNArgs(1),
 		RunE: func(cmd *cobra.Command, args []string) error {
 			return runGenericPutCommand(genericPutOptions{

--- a/node_propagate.go
+++ b/node_propagate.go
@@ -64,7 +64,7 @@ func propagateValueIndex(n *Node) error {
 			value.Index(n.Selector.Index).Set(n.Value)
 			return nil
 		}
-		n.Previous.Value = reflect.Append(value, n.Value)
+		n.Previous.setReflectValue(reflect.Append(value, n.Value))
 		return nil
 	}
 
@@ -80,7 +80,7 @@ func propagateValueNextAvailableIndex(n *Node) error {
 	value := unwrapValue(n.Previous.Value)
 
 	if value.Kind() == reflect.Slice {
-		n.Previous.Value = reflect.Append(value, n.Value)
+		n.Previous.setReflectValue(reflect.Append(value, n.Value))
 		return nil
 	}
 


### PR DESCRIPTION
- `dasel put document` is now supported.
- Fix an issue in that the read + write flags were ignored in `dasel put object`.
- Fix `dasel put object` command name/description.
- Update command descriptions.
- Fix an issue that stopped you being able to modify the root node.
- Fix some invalid selectors in the README.