### PR TITLE
Rename dasel_macos_amd64 to dasel_darwin_amd64

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -8,28 +8,60 @@ jobs:
   publish:
     strategy:
       matrix:
-        go-version: [1.15.x]
         os:
-          - ubuntu-latest
+          - linux
+          - darwin
+          - windows
+        arch:
+          - amd64
+          - 386
         include:
-          - os: ubuntu-latest
-            artifact_name: dasel
-    name: Publish for ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+          - os: linux
+            arch: amd64
+            artifact_name: dasel_linux_amd64
+            build_docker: true
+          - os: linux
+            arch: 386
+            artifact_name: dasel_linux_386
+            build_docker: false
+          - os: darwin
+            arch: amd64
+            artifact_name: dasel_darwin_amd64
+            build_docker: false
+          - os: darwin
+            arch: 386
+            artifact_name: dasel_darwin_386
+            build_docker: false
+          - os: windows
+            arch: amd64
+            artifact_name: dasel_windows_amd64.exe
+            build_docker: false
+          - os: windows
+            arch: 386
+            artifact_name: dasel_windows_386.exe
+            build_docker: false
+    name: Dev build ${{ matrix.os }} ${{ matrix.arch }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
           go-version: '^1.15.0' # The Go version to download (if necessary) and use.
       - name: Set env
-        run: echo RELEASE_VERSION=dev >> $GITHUB_ENV
+        run: echo RELEASE_VERSION=development >> $GITHUB_ENV
       - name: Build
-        run: go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
+      - name: Test version
+        run: ./target/release/${{ matrix.artifact_name }} --version
       - name: Build docker image
+        if: matrix.build_docker == true
         run: docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/Dockerfile -t tomwright/dasel:latest .
       - name: Docker login
+        if: matrix.build_docker == true
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u TomWright --password-stdin
-      - name: Docker tag ${{ env.RELEASE_VERSION }}
+      - name: Docker tag release
+        if: matrix.build_docker == true
         run: docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}
-      - name: Docker push ${{ env.RELEASE_VERSION }}
+      - name: Docker push release
+        if: matrix.build_docker == true
         run: docker push ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -21,7 +21,7 @@ jobs:
             asset_name: dasel_windows_amd64.exe
           - os: macos-latest
             artifact_name: dasel
-            asset_name: dasel_macos_amd64
+            asset_name: dasel_darwin_amd64
     name: Publish for ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -7,23 +7,46 @@ jobs:
   publish:
     strategy:
       matrix:
-        go-version: [1.15.x]
         os:
-          - ubuntu-latest
-          - windows-latest
-          - macos-latest
+          - linux
+          - darwin
+          - windows
+        arch:
+          - amd64
+          - 386
         include:
-          - os: ubuntu-latest
-            artifact_name: dasel
+          - os: linux
+            arch: amd64
+            artifact_name: dasel_linux_amd64
             asset_name: dasel_linux_amd64
-          - os: windows-latest
-            artifact_name: dasel.exe
-            asset_name: dasel_windows_amd64.exe
-          - os: macos-latest
-            artifact_name: dasel
+            build_docker: true
+          - os: linux
+            arch: 386
+            artifact_name: dasel_linux_386
+            asset_name: dasel_linux_386
+            build_docker: false
+          - os: darwin
+            arch: amd64
+            artifact_name: dasel_darwin_amd64
             asset_name: dasel_darwin_amd64
-    name: Publish for ${{ matrix.os }}
-    runs-on: ${{ matrix.os }}
+            build_docker: false
+          - os: darwin
+            arch: 386
+            artifact_name: dasel_darwin_386
+            asset_name: dasel_darwin_386
+            build_docker: false
+          - os: windows
+            arch: amd64
+            artifact_name: dasel_windows_amd64.exe
+            asset_name: dasel_windows_amd64.exe
+            build_docker: false
+          - os: windows
+            arch: 386
+            artifact_name: dasel_windows_386.exe
+            asset_name: dasel_windows_386.exe
+            build_docker: false
+    name: Build ${{ matrix.os }} ${{ matrix.arch }}
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
@@ -31,13 +54,10 @@ jobs:
           go-version: '^1.15.0' # The Go version to download (if necessary) and use.
       - name: Set env
         run: echo RELEASE_VERSION=${GITHUB_REF:10} >> $GITHUB_ENV
-        if: runner.os != 'Windows'
-      - name: Set env (Windows)
-        run: echo RELEASE_VERSION=${GITHUB_REF:10} >> $GITHUB_ENV
-        shell: bash
-        if: runner.os == 'Windows'
       - name: Build
-        run: go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
+      - name: Test version
+        run: ./target/release/${{ matrix.artifact_name }} --version
       - name: Upload binaries to release
         uses: svenstaro/upload-release-action@v1-release
         with:
@@ -46,20 +66,20 @@ jobs:
           asset_name: ${{ matrix.asset_name }}
           tag: ${{ github.ref }}
       - name: Build docker image
-        if: runner.os == 'Linux'
+        if: matrix.build_docker == true
         run: docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/Dockerfile -t tomwright/dasel:latest .
       - name: Docker login
-        if: runner.os == 'Linux'
+        if: matrix.build_docker == true
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u TomWright --password-stdin
       - name: Docker tag latest
-        if: runner.os == 'Linux'
+        if: matrix.build_docker == true
         run: docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:latest
       - name: Docker tag release
-        if: runner.os == 'Linux'
+        if: matrix.build_docker == true
         run: docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}
       - name: Docker push latest
-        if: runner.os == 'Linux'
+        if: matrix.build_docker == true
         run: docker push ghcr.io/tomwright/dasel:latest
       - name: Docker push release
-        if: runner.os == 'Linux'
+        if: matrix.build_docker == true
         run: docker push ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -2,16 +2,12 @@ on: [push, pull_request]
 name: Test
 jobs:
   test:
-    strategy:
-      matrix:
-        go-version: [1.15.x]
-        platform: [ubuntu-latest]
-    runs-on: ${{ matrix.platform }}
+    runs-on: ubuntu-latest
     steps:
       - name: Install Go
         uses: actions/setup-go@v1
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: '^1.15.0'
       - name: Checkout code
         uses: actions/checkout@v1
       - uses: actions/cache@v1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Build workflows now updated to run on ubuntu-latest and use a matrix to build assets for `linux`, `darwin` and
+`windows` for both `amd64` and `386`.
+
+### Fixed
+
 - Release asset for macos/darwin is now named `dasel_darwin_amd64` instead of `dasel_macos_amd64`.
+- Self-updater now identifies `dev` version as development.
 
 ## [v1.12.0] - 2021-01-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet.
+### Changed
+
+- Release asset for macos/darwin is now named `dasel_darwin_amd64` instead of `dasel_macos_amd64`.
 
 ## [v1.12.0] - 2021-01-02
 

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ mv ./dasel /usr/local/bin/dasel
 ##### Mac OS amd64
 You may have to `brew install wget` in order for this to work.
 ```bash
-curl -s https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep macos_amd64 | cut -d '"' -f 4 | wget -qi - && mv dasel_macos_amd64 dasel && chmod +x dasel
+curl -s https://api.github.com/repos/tomwright/dasel/releases/latest | grep browser_download_url | grep darwin_amd64 | cut -d '"' -f 4 | wget -qi - && mv dasel_darwin_amd64 dasel && chmod +x dasel
 mv ./dasel /usr/local/bin/dasel
 ```
 
@@ -1005,7 +1005,7 @@ dasel -p json -m '.(?:name.last=Wright).name.first'
 The following line will return the download URL for the latest macOS dasel release:
 
 ```bash
-curl https://api.github.com/repos/tomwright/dasel/releases/latest | dasel -p json --plain '.assets.(name=dasel_macos_amd64).browser_download_url'
+curl https://api.github.com/repos/tomwright/dasel/releases/latest | dasel -p json --plain '.assets.(name=dasel_darwin_amd64).browser_download_url'
 ```
 
 ### jq to dasel

--- a/internal/selfupdate/version.go
+++ b/internal/selfupdate/version.go
@@ -25,7 +25,7 @@ func (v *Version) String() string {
 
 // IsDevelopment returns true if it's a development version.
 func (v *Version) IsDevelopment() bool {
-	return v.Raw == "development"
+	return v.Raw == "development" || v.Raw == "dev"
 }
 
 // Compare compares this version to the other version.


### PR DESCRIPTION
This causes the released asset for mac os to be named after `darwin` instead of `macos`. This better resembles the actual architecture and allows users to use `uname` to find the appropriate release.