### PR TITLE
Disable cgo when building binaries

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -54,7 +54,7 @@ jobs:
       - name: Set env
         run: echo RELEASE_VERSION=development >> $GITHUB_ENV
       - name: Build
-        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
       - name: Test version
         if: matrix.test_version == true
         run: ./target/release/${{ matrix.artifact_name }} --version

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -63,7 +63,7 @@ jobs:
       - name: Set env
         run: echo RELEASE_VERSION=${GITHUB_REF:10} >> $GITHUB_ENV
       - name: Build
-        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
       - name: Test version
         if: matrix.test_version == true
         run: ./target/release/${{ matrix.artifact_name }} --version


### PR DESCRIPTION
https://golang.org/cmd/cgo/
> The cgo tool is enabled by default for native builds on systems where it is expected to work. It is disabled by default when cross-compiling. 

This fact caused linux amd64 builds to build using CGO_ENABLED, and they were therefor dynamically linked: https://github.com/TomWright/dasel/discussions/93

Updating the build command like this should cause all executables to be static.