### PR TITLE
Optionally disable self-updater

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet.
+### Changed
+
+- Optional `noupdater` build tag to disable the self-update command.
 
 ## [v1.14.1] - 2021-04-15
 

--- a/internal/command/update.go
+++ b/internal/command/update.go
@@ -1,3 +1,5 @@
+// +build !noupdater
+
 package command
 
 import (

--- a/internal/command/update_stub.go
+++ b/internal/command/update_stub.go
@@ -1,0 +1,12 @@
+// +build noupdater
+
+package command
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/tomwright/dasel/internal/selfupdate"
+)
+
+func updateCommand(updater *selfupdate.Updater) *cobra.Command {
+	return &cobra.Command{}
+}


### PR DESCRIPTION
Small patch to disable the self-updating functionally by introducing a new `noupdater` build tag. The rationale behind this is that having an inclusive command for updating the binary can cause a disparity in versions distributed by package maintainers.

As a sample demonstration when using the build tag:

```shell
% go build -tags noupdater -o dasel cmd/dasel/main.go
% ./dasel
Query and modify data structures using selector strings.

Usage:
  dasel [command]

Available Commands:
  help        Help about any command
  put         Update properties in the given file.
  select      Select properties from the given file.

Flags:
  -h, --help      help for dasel
  -v, --version   version for dasel

Additional help topics:
  dasel

Use "dasel [command] --help" for more information about a command.
```

As you can see the update command is omitted from the output since the stub function does not return anything. Cheers!

Signed-off-by: Lewis Cook <lcook@FreeBSD.org>