### PR TITLE
ci: alpine Docker image

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -70,13 +70,21 @@ jobs:
         run: ./target/release/${{ matrix.artifact_name }} --version
       - name: Build docker image
         if: matrix.build_docker == true
-        run: docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/Dockerfile -t tomwright/dasel:latest .
+        run: |
+          docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/Dockerfile -t tomwright/dasel:latest .
+          docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/alpine.Dockerfile -t tomwright/dasel:alpine .
       - name: Docker login
         if: matrix.build_docker == true
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u TomWright --password-stdin
       - name: Docker tag release
         if: matrix.build_docker == true
-        run: docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}
+        run: |
+          docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}
+          docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}-buster-slim
+          docker tag tomwright/dasel:alpine ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}-alpine
       - name: Docker push release
         if: matrix.build_docker == true
-        run: docker push ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}
+        run: |
+          docker push ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}
+          docker push ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}-buster-slim
+          docker push ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}-alpine

--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -73,6 +73,11 @@ jobs:
         run: |
           docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/Dockerfile -t tomwright/dasel:latest .
           docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/alpine.Dockerfile -t tomwright/dasel:alpine .
+      - name: Test docker image
+        if: matrix.build_docker == true
+        run: |
+          echo '{"hello": "World"}' | docker run -i --rm tomwright/dasel:latest -p json '.hello'
+          echo '{"hello": "World"}' | docker run -i --rm tomwright/dasel:alpine -p json '.hello'
       - name: Docker login
         if: matrix.build_docker == true
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u TomWright --password-stdin

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -91,6 +91,11 @@ jobs:
         run: |
           docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/Dockerfile -t tomwright/dasel:latest .
           docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/alpine.Dockerfile -t tomwright/dasel:alpine .
+      - name: Test docker image
+        if: matrix.build_docker == true
+        run: |
+          echo '{"hello": "World"}' | docker run -i --rm tomwright/dasel:latest -p json '.hello'
+          echo '{"hello": "World"}' | docker run -i --rm tomwright/dasel:alpine -p json '.hello'
       - name: Docker login
         if: matrix.build_docker == true
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u TomWright --password-stdin

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -88,22 +88,34 @@ jobs:
           tag: ${{ github.ref }}
       - name: Build docker image
         if: matrix.build_docker == true
-        run: docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/Dockerfile -t tomwright/dasel:latest .
+        run: |
+          docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/Dockerfile -t tomwright/dasel:latest .
+          docker build --build-arg daselpath=target/release/${{ matrix.artifact_name }} -f docker/alpine.Dockerfile -t tomwright/dasel:alpine .
       - name: Docker login
         if: matrix.build_docker == true
         run: echo "${{ secrets.GHCR_PAT }}" | docker login ghcr.io -u TomWright --password-stdin
       - name: Docker tag latest
         if: matrix.build_docker == true
-        run: docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:latest
+        run: |
+          docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:latest
+          docker tag tomwright/dasel:alpine ghcr.io/tomwright/dasel:alpine
       - name: Docker tag release
         if: matrix.build_docker == true
-        run: docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}
+        run: |
+          docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}
+          docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}-buster-slim
+          docker tag tomwright/dasel:alpine ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}-alpine
       - name: Docker push latest
         if: matrix.build_docker == true
-        run: docker push ghcr.io/tomwright/dasel:latest
+        run: |
+          docker push ghcr.io/tomwright/dasel:latest
+          docker push ghcr.io/tomwright/dasel:alpine
       - name: Docker push release
         if: matrix.build_docker == true
-        run: docker push ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}
+        run: |
+          docker push ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}
+          docker push ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}-buster-slim
+          docker push ghcr.io/tomwright/dasel:${{ env.RELEASE_VERSION }}-alpine
       - name: Homebrew bump formula
         if: matrix.bump_homebrew == true
         uses: dawidd6/action-homebrew-bump-formula@v3.7.2

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -98,6 +98,7 @@ jobs:
         if: matrix.build_docker == true
         run: |
           docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:latest
+          docker tag tomwright/dasel:latest ghcr.io/tomwright/dasel:buster-slim
           docker tag tomwright/dasel:alpine ghcr.io/tomwright/dasel:alpine
       - name: Docker tag release
         if: matrix.build_docker == true
@@ -109,6 +110,7 @@ jobs:
         if: matrix.build_docker == true
         run: |
           docker push ghcr.io/tomwright/dasel:latest
+          docker push ghcr.io/tomwright/dasel:buster-slim
           docker push ghcr.io/tomwright/dasel:alpine
       - name: Docker push release
         if: matrix.build_docker == true

--- a/docker/alpine.Dockerfile
+++ b/docker/alpine.Dockerfile
@@ -1,0 +1,10 @@
+FROM alpine
+
+ARG daselpath=./dasel
+
+WORKDIR /root
+COPY $daselpath /usr/local/bin/dasel
+RUN chmod +x /usr/local/bin/dasel
+
+ENTRYPOINT ["/usr/local/bin/dasel"]
+CMD []


### PR DESCRIPTION
This would be a much more lightweight image, with the same tool. Furthermore, it will be a lot faster and easier to add extra packages such as `curl` (i.e. a fast and clean `apk add --no-cache curl` instead of a slow `apt-get update && apt-get install curl -y` which adds harder to remove cache.
This does still need you to set up a pipeline to create `ghcr.io/tomwright/dasel:alpine`.