### PR TITLE
Fix delete example

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ See [put documentation](https://daseldocs.tomwright.me/usage/put).
 echo '{
   "email": "contact@tomwright.me",
   "name": "Tom"
-}' | dasel delete -r json '.email' 'contact@tomwright.me'
+}' | dasel delete -p json '.email'
 {
   "name": "Tom"
 }


### PR DESCRIPTION
The current delete example wasn't using the `-p` flag and was passing an unnecessary value.