### PR TITLE
handle datetime values properly in .toml

### DIFF
--- a/storage/toml.go
+++ b/storage/toml.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"fmt"
 	"github.com/pelletier/go-toml"
+	"time"
 )
 
 func init() {
@@ -66,6 +67,8 @@ func (p *TOMLParser) ToBytes(value interface{}, options ...ReadWriteOption) ([]b
 				}
 			}
 		}
+	case time.Time:
+		buf.Write([]byte(fmt.Sprintf("%s\n", d.Format(time.RFC3339))))
 	default:
 		if err := enc.Encode(d); err != nil {
 			if err.Error() == "Only a struct or map can be marshaled to TOML" {


### PR DESCRIPTION
`toml` may include datetime values.

* [toml/toml.md at main · toml-lang/toml](https://github.com/toml-lang/toml/blob/main/toml.md#offset-date-time)

However, currently those values cannot be selected properly.

~~~sh
$ cat /tmp/dasel_test.toml
[basic]
  date = 1979-05-27T07:32:00+09:00

$ ./dasel -f /tmp/dasel_test.toml -s '.basic'
date = 1979-05-27T07:32:00+09:00

$ ./dasel -f /tmp/dasel_test.toml -s '.basic.date'
(no output)
~~~

 This PR fixes the problem and enables to select datetime value properly.

~~~sh
$ ./dasel -f /tmp/dasel_test.toml -s '.basic.date'
1979-05-27T07:32:00+09:00
~~~