### PR TITLE
add optional search selector '(#:<key>=<value>)'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Nothing yet
+### Added
+
+- Search optional selector - `(#:key=value)`
 
 ## [v1.25.1] - 2022-06-29
 
-## Added
+### Added
 
 - Pre-commit hooks for validate command.
 

--- a/internal/command/root_select_test.go
+++ b/internal/command/root_select_test.go
@@ -531,6 +531,23 @@ func TestRootCmd_Select_JSON(t *testing.T) {
 ]
 `, nil, "-m"))
 
+	t.Run("SearchOptional", selectTest(`{
+  "users": [
+    {
+      "name": "Tom",
+      "blocked": true
+    },
+    {
+      "name": "Jim",
+      "blocked": false
+    },
+    {
+      "name": "Frank"
+    }
+  ]
+}`, "json", `.users.(#:blocked=true).name`, `Tom
+`, nil, "-m", "--plain"))
+
 }
 
 func TestRootCmd_Select_YAML(t *testing.T) {

--- a/node.go
+++ b/node.go
@@ -2,11 +2,12 @@ package dasel
 
 import (
 	"fmt"
-	"github.com/tomwright/dasel/storage"
 	"io"
 	"os"
 	"reflect"
 	"regexp"
+
+	"github.com/tomwright/dasel/storage"
 )
 
 // Selector represents the selector for a node.
@@ -106,7 +107,7 @@ func nilValue() reflect.Value {
 }
 
 func unwrapValue(value reflect.Value) reflect.Value {
-	if value.Kind() == reflect.Interface {
+	if value.Kind() == reflect.Interface && !value.IsNil() {
 		return value.Elem()
 	}
 	return value

--- a/node_query_multiple.go
+++ b/node_query_multiple.go
@@ -454,7 +454,9 @@ func findNodesSearchRecursiveWork(selector Selector, previousNode *Node, createI
 // If any of those nodes match the checks they are returned.
 func findNodesSearchRecursive(selector Selector, previousNode *Node, createIfNotExists bool, firstNode bool) ([]*Node, error) {
 	if !isValid(previousNode.Value) {
-		return nil, &UnexpectedPreviousNilValue{Selector: selector.Raw}
+		if selector.Type != "SEARCH_OPTIONAL" {
+			return nil, &UnexpectedPreviousNilValue{Selector: selector.Raw}
+		}
 	}
 	return findNodesSearchRecursiveWork(selector, previousNode, createIfNotExists, firstNode, unwrapValue(previousNode.Value))
 }
@@ -687,6 +689,8 @@ func findNodes(selector Selector, previousNode *Node, createIfNotExists bool) ([
 	case "DYNAMIC":
 		res, err = findNodesDynamic(selector, previousNode.Value, createIfNotExists)
 	case "SEARCH":
+		res, err = findNodesSearch(selector, previousNode, createIfNotExists)
+	case "SEARCH_OPTIONAL":
 		res, err = findNodesSearch(selector, previousNode, createIfNotExists)
 	default:
 		err = &UnsupportedSelector{Selector: selector.Raw}

--- a/parse_selector.go
+++ b/parse_selector.go
@@ -164,9 +164,6 @@ func processParseSelectorSearchOptional(selector string, sel Selector) (Selector
 	if err != nil {
 		return sel, err
 	}
-	if len(dynamicGroups) != 1 {
-		return sel, fmt.Errorf("require exactly 1 group in search selector")
-	}
 
 	for _, g := range dynamicGroups {
 		parts := FindDynamicSelectorParts(g)


### PR DESCRIPTION
Optional Search selectors recursively all the data below the current
node and return all of the results, if at least one result is found.

This is different from standard search, where a search selector must
exist in _all_ documents passed through dasel. The difference with
this selector is that so long as one match is found, dasel will
print the result.

Based on dicussion at https://github.com/TomWright/dasel/discussions/234