### PR TITLE
add darwin amd64 builds

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -33,6 +33,11 @@ jobs:
             artifact_name: dasel_darwin_amd64
             build_docker: false
             test_version: false
+          - os: darwin
+            arch: arm64
+            artifact_name: dasel_darwin_arm64
+            build_docker: false
+            test_version: false
           - os: windows
             arch: amd64
             artifact_name: dasel_windows_amd64.exe
@@ -56,8 +61,6 @@ jobs:
         exclude:
           - os: darwin
             arch: 386
-          - os: darwin
-            arch: arm64
           - os: windows
             arch: arm64
           - os: windows

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -40,6 +40,12 @@ jobs:
             build_docker: false
             test_version: false
             test_execution: false
+          - os: darwin
+            arch: arm64
+            artifact_name: dasel_darwin_arm64
+            build_docker: false
+            test_version: false
+            test_execution: false
           - os: windows
             arch: amd64
             artifact_name: dasel_windows_amd64.exe
@@ -67,8 +73,6 @@ jobs:
         exclude:
           - os: darwin
             arch: 386
-          - os: darwin
-            arch: arm64
           - os: windows
             arch: arm64
           - os: windows

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,6 +35,12 @@ jobs:
             asset_name: dasel_darwin_amd64
             build_docker: false
             test_version: false
+          - os: darwin
+            arch: arm64
+            artifact_name: dasel_darwin_arm64
+            asset_name: dasel_darwin_arm64
+            build_docker: false
+            test_version: false
           - os: windows
             arch: amd64
             artifact_name: dasel_windows_amd64.exe
@@ -62,8 +68,6 @@ jobs:
         exclude:
             - os: darwin
               arch: 386
-            - os: darwin
-              arch: arm64
             - os: windows
               arch: arm64
             - os: windows


### PR DESCRIPTION
Addresses issue #225 by including builds for the darwin arm64 os/arch combo.

I received a M1 MacBook Pro on Friday and have been testing, seems to be working as expected.