### PR TITLE
Add `__complete` to subCommands so that completion works.

### DIFF
--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -35,7 +35,7 @@ func ChangeDefaultCommand(cmd *cobra.Command, command string, blacklistedArgs ..
 
 		// The completion command is registered internally during execution so cmd.Commands() can't
 		// pick it up here.
-		subCommands := []string{"completion"}
+		subCommands := []string{"completion", "__complete"}
 		for _, subCmd := range cmd.Commands() {
 			subCommands = append(subCommands, append(subCmd.Aliases, subCmd.Name())...)
 		}


### PR DESCRIPTION
Completion calls `__complete` followed by the text to be completed. The check in `getReadParser` prevents this from working so it must be added to `subCommands` to bypass this check.
