### PR TITLE
Fixing the error caused by null elements in array

### DIFF
--- a/value.go
+++ b/value.go
@@ -344,7 +344,9 @@ func derefSlice(value reflect.Value) reflect.Value {
 	res := reflect.MakeSlice(unpacked.Type(), unpacked.Len(), unpacked.Len())
 
 	for i := 0; i < unpacked.Len(); i++ {
-		res.Index(i).Set(deref(unpacked.Index(i)))
+		if v := deref(unpacked.Index(i)); v.IsValid() {
+			res.Index(i).Set(v)
+		}
 	}
 
 	return res


### PR DESCRIPTION
fixes #296

It was failing when working on an array which has `null` elements. It is basically caused by trying to set the `reflect.Value` of the `nil` pointer to slice index.

```
panic: reflect: call of reflect.Value.Set on zero Value

goroutine 1 [running]:
reflect.flag.mustBeExportedSlow(0x1517da0?)
	reflect/value.go:235 +0xc5
reflect.flag.mustBeExported(...)
	reflect/value.go:229
reflect.Value.Set({0x1517da0?, 0xc0002a8620?, 0x7?}, {0x0?, 0x0?, 0xc0002b1790?})
	reflect/value.go:2155 +0x9f
github.com/tomwright/dasel/v2.derefSlice({0x1517da0?, 0xc000267cb0?, 0xc0001f4a20?})
	github.com/tomwright/dasel/v2/value.go:347 +0x1ad
github.com/tomwright/dasel/v2.deref({0x1517da0?, 0xc000267cb0?, 0x0?})
	github.com/tomwright/dasel/v2/value.go:370 +0x65
github.com/tomwright/dasel/v2.derefMap({0x1517da0?, 0xc00025ae60?, 0xc0002b1901?})
	github.com/tomwright/dasel/v2/value.go:359 +0x13d
...
```

an example of how it works after the changes:

```json
[
  {
    "a": "alice",
    "b": 9,
    "c": [
      null,
      "bob",
      13,
      null,
      9,5,
      null
    ]
  },
  null
]
```
 
```
$ dasel -r json -w yaml -f test.json
```

``` yaml
- a: alice
  b: 9
  c:
  - null
  - bob
  - 13
  - null
  - 9
  - 5
  - null
- null
```