### PR TITLE
Update references to `internal.Version` for v2

### DIFF
--- a/.github/workflows/build-dev.yaml
+++ b/.github/workflows/build-dev.yaml
@@ -77,7 +77,7 @@ jobs:
       - name: Set env
         run: echo RELEASE_VERSION=development >> $GITHUB_ENV
       - name: Build
-        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/v2/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
       - name: Test version
         if: matrix.test_version == true
         run: ./target/release/${{ matrix.artifact_name }} --version

--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -89,7 +89,7 @@ jobs:
       - name: Set env
         run: echo RELEASE_VERSION=development >> $GITHUB_ENV
       - name: Build
-        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/v2/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
       - name: Test version
         if: matrix.test_version == true
         run: ./target/release/${{ matrix.artifact_name }} --version

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -84,7 +84,7 @@ jobs:
       - name: Set env
         run: echo RELEASE_VERSION=${GITHUB_REF:10} >> $GITHUB_ENV
       - name: Build
-        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
+        run: GOOS=${{ matrix.os }} GOARCH=${{ matrix.arch }} CGO_ENABLED=0 go build -o target/release/${{ matrix.artifact_name }} -ldflags="-X 'github.com/tomwright/dasel/v2/internal.Version=${{ env.RELEASE_VERSION }}'" ./cmd/dasel
       - name: Test version
         if: matrix.test_version == true
         run: ./target/release/${{ matrix.artifact_name }} --version


### PR DESCRIPTION
Without the `v2` in `github.com/tomwright/dasel/v2/internal.Version` the reference is broken. This leads to all binaries having version number set to `development`.

```bash
$ dasel --version
dasel version development
```