### PR TITLE
orDefault function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- `orDefault()` function.
+- `orDefault()` function. [See docs](https://daseldocs.tomwright.me/functions/ordefault)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `orDefault()` function.
+
 ### Fixed
 
 - Resolved an issue with YAML parser that was causing strings to be read as booleans.

--- a/func.go
+++ b/func.go
@@ -68,6 +68,7 @@ func standardFunctions() *FunctionCollection {
 		LastFunc,
 		PropertyFunc,
 		AppendFunc,
+		OrDefaultFunc,
 
 		// Filters
 		FilterFunc,

--- a/func_or_default.go
+++ b/func_or_default.go
@@ -27,7 +27,7 @@ var OrDefaultFunc = BasicFunction{
 				notFound := false
 				if errors.Is(err, &ErrPropertyNotFound{}) {
 					notFound = true
-				} else if errors.Is(err, &ErrIndexNotFound{}) {
+				} else if errors.Is(err, &ErrIndexNotFound{Index: -1}) {
 					notFound = true
 				}
 				if notFound {
@@ -36,10 +36,13 @@ var OrDefaultFunc = BasicFunction{
 					return Value{}, err
 				}
 			}
-			if len(gotValues) != 1 {
-				return Value{}, fmt.Errorf("orDefault expects selector to return exactly 1 value")
+			if len(gotValues) == 1 && err == nil {
+				return gotValues[0], nil
 			}
-			return gotValues[0], err
+			if err != nil {
+				return Value{}, err
+			}
+			return Value{}, fmt.Errorf("orDefault expects selector to return exactly 1 value")
 		}
 
 		res := make(Values, 0)

--- a/func_or_default.go
+++ b/func_or_default.go
@@ -5,9 +5,6 @@ import (
 	"fmt"
 )
 
-// ErrPropertyNotFound
-// ErrIndexNotFound
-
 var OrDefaultFunc = BasicFunction{
 	name: "orDefault",
 	runFn: func(c *Context, s *Step, args []string) (Values, error) {

--- a/func_or_default.go
+++ b/func_or_default.go
@@ -1,0 +1,58 @@
+package dasel
+
+import (
+	"errors"
+	"fmt"
+)
+
+// ErrPropertyNotFound
+// ErrIndexNotFound
+
+var OrDefaultFunc = BasicFunction{
+	name: "orDefault",
+	runFn: func(c *Context, s *Step, args []string) (Values, error) {
+		if err := requireExactlyXArgs("orDefault", args, 2); err != nil {
+			return nil, err
+		}
+
+		input := s.inputs()
+
+		if c.CreateWhenMissing() {
+			input = input.initEmptydencodingMaps()
+		}
+
+		runSubselect := func(value Value, selector string, defaultSelector string) (Value, error) {
+			gotValues, err := c.subSelect(value, selector)
+			if err != nil {
+				notFound := false
+				if errors.Is(err, &ErrPropertyNotFound{}) {
+					notFound = true
+				} else if errors.Is(err, &ErrIndexNotFound{}) {
+					notFound = true
+				}
+				if notFound {
+					gotValues, err = c.subSelect(value, defaultSelector)
+				} else {
+					return Value{}, err
+				}
+			}
+			if len(gotValues) != 1 {
+				return Value{}, fmt.Errorf("orDefault expects selector to return exactly 1 value")
+			}
+			return gotValues[0], err
+		}
+
+		res := make(Values, 0)
+
+		for _, val := range input {
+			resolvedValue, err := runSubselect(val, args[0], args[1])
+			if err != nil {
+				return nil, err
+			}
+
+			res = append(res, resolvedValue)
+		}
+
+		return res, nil
+	},
+}

--- a/func_or_default_test.go
+++ b/func_or_default_test.go
@@ -9,7 +9,7 @@ func TestOrDefaultFunc(t *testing.T) {
 		"orDefault()",
 		map[string]interface{}{},
 		&ErrUnexpectedFunctionArgs{
-			Function: "property",
+			Function: "orDefault",
 			Args:     []string{},
 		}),
 	)

--- a/func_or_default_test.go
+++ b/func_or_default_test.go
@@ -1,0 +1,86 @@
+package dasel
+
+import (
+	"testing"
+)
+
+func TestOrDefaultFunc(t *testing.T) {
+	t.Run("Args", selectTestErr(
+		"orDefault()",
+		map[string]interface{}{},
+		&ErrUnexpectedFunctionArgs{
+			Function: "property",
+			Args:     []string{},
+		}),
+	)
+
+	t.Run("OriginalAndDefaultNotFoundProperty", selectTestErr(
+		"orDefault(a,b)",
+		map[string]interface{}{"x": "y"},
+		&ErrPropertyNotFound{
+			Property: "b",
+		}),
+	)
+
+	t.Run("OriginalAndDefaultNotFoundIndex", selectTestErr(
+		"orDefault(x.[1],x.[2])",
+		map[string]interface{}{"x": []int{1}},
+		&ErrIndexNotFound{
+			Index: 2,
+		}),
+	)
+
+	original := map[string]interface{}{
+		"name": map[string]interface{}{
+			"first": "Tom",
+			"last":  "Wright",
+		},
+		"colours": []interface{}{
+			"red", "green", "blue",
+		},
+	}
+
+	t.Run(
+		"FirstNameOrLastName",
+		selectTest(
+			"orDefault(name.first,name.last)",
+			original,
+			[]interface{}{
+				"Tom",
+			},
+		),
+	)
+
+	t.Run(
+		"MiddleNameOrDefault",
+		selectTest(
+			"orDefault(name.middle,string(default))",
+			original,
+			[]interface{}{
+				"default",
+			},
+		),
+	)
+
+	t.Run(
+		"FirstColourOrSecondColour",
+		selectTest(
+			"orDefault(colours.[0],colours.[2])",
+			original,
+			[]interface{}{
+				"red",
+			},
+		),
+	)
+
+	t.Run(
+		"FourthColourOrDefault",
+		selectTest(
+			"orDefault(colours.[3],string(default))",
+			original,
+			[]interface{}{
+				"default",
+			},
+		),
+	)
+}

--- a/internal/command/select_test.go
+++ b/internal/command/select_test.go
@@ -228,4 +228,28 @@ octal: 8`)),
 		nil,
 	))
 
+	t.Run("OrDefault", runTest(
+		[]string{"-r", "json", "all().orDefault(locale,string(nope))"},
+		[]byte(`{
+  "-LCr5pXw_fN32IqNDr4E": {
+    "bookCategory": "poetry",
+    "locale": "en-us",
+    "mediaType": "book",
+    "publisher": "Pomelo Books",
+    "title": "Sound Waves",
+    "type": "poetry"
+  },
+  "-LDDHjkdY0306fZdvhEQ": {
+    "ISBN13": "978-1534402966",
+    "bookCategory": "fiction",
+    "title": "What Can You Do with a Toolbox?",
+    "type": "picturebook"
+  }
+}`),
+		newline([]byte(`"en-us"
+"nope"`)),
+		nil,
+		nil,
+	))
+
 }

--- a/internal/command/select_test.go
+++ b/internal/command/select_test.go
@@ -252,6 +252,30 @@ octal: 8`)),
 		nil,
 	))
 
+	t.Run("OrDefaultLookup", runTest(
+		[]string{"-r", "json", "all().orDefault(locale,bookCategory)"},
+		[]byte(`{
+  "-LCr5pXw_fN32IqNDr4E": {
+    "bookCategory": "poetry",
+    "locale": "en-us",
+    "mediaType": "book",
+    "publisher": "Pomelo Books",
+    "title": "Sound Waves",
+    "type": "poetry"
+  },
+  "-LDDHjkdY0306fZdvhEQ": {
+    "ISBN13": "978-1534402966",
+    "bookCategory": "fiction",
+    "title": "What Can You Do with a Toolbox?",
+    "type": "picturebook"
+  }
+}`),
+		newline([]byte(`"en-us"
+"fiction"`)),
+		nil,
+		nil,
+	))
+
 	t.Run("Issue364 - CSV root element part 1", runTest(
 		[]string{"-r", "csv", "-w", "csv", "all().merge()"},
 		[]byte(`A,B,C


### PR DESCRIPTION
Add a new function `orDefault`.

It takes 2 arguments:
- A selector string
- A selector string that will be used as a fallback

The first selector is expected to return a single value.
The second selector is used if the first causes a NotFound error and is expected to always return a single value.

Example usage:
```bash
$ echo '{
  "-LCr5pXw_fN32IqNDr4E": {
    "bookCategory": "poetry",
    "locale": "en-us",
    "mediaType": "book",
    "publisher": "Pomelo Books",
    "title": "Sound Waves",
    "type": "poetry"
  },
  "-LDDHjkdY0306fZdvhEQ": {
    "ISBN13": "978-1534402966",
    "bookCategory": "fiction",
    "title": "What Can You Do with a Toolbox?",
    "type": "picturebook"
  }
}' | dasel -r json 'all().mapOf(projectId,key(),title,title,bookCategory,bookCategory,type,type,locale,orDefault(locale,string(unknown)))'
{
  "bookCategory": "poetry",
  "locale": "en-us",
  "projectId": "-LCr5pXw_fN32IqNDr4E",
  "title": "Sound Waves",
  "type": "poetry"
}
{
  "bookCategory": "fiction",
  "locale": "unknown",
  "projectId": "-LDDHjkdY0306fZdvhEQ",
  "title": "What Can You Do with a Toolbox?",
  "type": "picturebook"
}
```