### PR TITLE
Add 'indent' parameter to 'put' command

### DIFF
--- a/internal/command/options.go
+++ b/internal/command/options.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tomwright/dasel/v2/storage"
 	"io"
 	"os"
+	"strconv"
 )
 
 type readOptions struct {
@@ -94,6 +95,8 @@ type writeOptions struct {
 	CsvComma string
 	// CsvUseCRLF determines whether CRLF is used when writing CSV files.
 	CsvUseCRLF bool
+
+	Indent int
 }
 
 func (o *writeOptions) writeToStdout() bool {
@@ -147,6 +150,10 @@ func (o *writeOptions) writeValues(cmd *cobra.Command, readOptions *readOptions,
 
 	if o.CsvComma != "" {
 		options = append(options, storage.CsvCommaOption([]rune(o.CsvComma)[0]))
+	}
+
+	if o.Indent != 0 {
+		options = append(options, storage.IndentOption(strconv.Itoa(o.Indent)))
 	}
 
 	writer := o.Writer

--- a/internal/command/put.go
+++ b/internal/command/put.go
@@ -32,6 +32,7 @@ func putFlags(cmd *cobra.Command) {
 	cmd.Flags().Bool("pretty", true, "Pretty print the output.")
 	cmd.Flags().Bool("colour", false, "Print colourised output.")
 	cmd.Flags().Bool("escape-html", false, "Escape HTML tags when writing output.")
+	cmd.Flags().Int("indent", 0, "The indention level when writing files.")
 	cmd.Flags().String("csv-comma", ",", "Comma separator to use when working with csv files.")
 	cmd.Flags().String("csv-write-comma", "", "Comma separator used when writing csv files. Overrides csv-comma when writing.")
 	cmd.Flags().String("csv-comment", "", "Comma separator used when reading csv files.")
@@ -51,6 +52,7 @@ func putRunE(cmd *cobra.Command, args []string) error {
 	colourFlag, _ := cmd.Flags().GetBool("colour")
 	escapeHTMLFlag, _ := cmd.Flags().GetBool("escape-html")
 	outFlag, _ := cmd.Flags().GetString("out")
+	indent, _ := cmd.Flags().GetInt("indent")
 	csvComma, _ := cmd.Flags().GetString("csv-comma")
 	csvWriteComma, _ := cmd.Flags().GetString("csv-write-comma")
 	csvComment, _ := cmd.Flags().GetString("csv-comment")
@@ -71,6 +73,7 @@ func putRunE(cmd *cobra.Command, args []string) error {
 			PrettyPrint: prettyPrintFlag,
 			Colourise:   colourFlag,
 			EscapeHTML:  escapeHTMLFlag,
+			Indent:      indent,
 			CsvComma:    csvWriteComma,
 			CsvUseCRLF:  csvCRLF,
 		},

--- a/storage/yaml.go
+++ b/storage/yaml.go
@@ -7,6 +7,7 @@ import (
 	"github.com/tomwright/dasel/v2/dencoding"
 	"github.com/tomwright/dasel/v2/util"
 	"io"
+	"strconv"
 )
 
 func init() {
@@ -92,8 +93,10 @@ func (p *YAMLParser) ToBytes(value dasel.Value, options ...ReadWriteOption) ([]b
 				colourise = value
 			}
 		case OptionIndent:
-			if value, ok := o.Value.(int); ok {
-				encoderOptions = append(encoderOptions, dencoding.YAMLEncodeIndent(value))
+			if value, ok := o.Value.(string); ok {
+				if indent, err := strconv.Atoi(value); err == nil {
+					encoderOptions = append(encoderOptions, dencoding.YAMLEncodeIndent(indent))
+				}
 			}
 		}
 	}


### PR DESCRIPTION
I would like to add a new command line parameter for the put-command to set the indention level for various outputs. The different parsers are already respecting the `IndentOption` but it is not possible to pass it via the cli.