### PR TITLE
Generate manpages

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,8 +13,10 @@ require (
 )
 
 require (
+	github.com/cpuguy83/go-md2man/v2 v2.0.3 // indirect
 	github.com/dlclark/regexp2 v1.10.0 // indirect
 	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
+	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,7 @@ github.com/alecthomas/repr v0.2.0 h1:HAzS41CIzNW5syS8Mf9UwXhNH1J9aix/BvDRf1Ml2Yk
 github.com/alecthomas/repr v0.2.0/go.mod h1:Fr0507jx4eOXV7AlPV6AVZLYrLIuIeSOWtW57eE/O/4=
 github.com/clbanning/mxj/v2 v2.7.0 h1:WA/La7UGCanFe5NpHF0Q3DNtnCsVoxbPKuyBNHWRyME=
 github.com/clbanning/mxj/v2 v2.7.0/go.mod h1:hNiWqW14h+kc+MdF9C6/YoRfjEJoR3ou6tn/Qo+ve2s=
+github.com/cpuguy83/go-md2man/v2 v2.0.3 h1:qMCsGGgs+MAzDFyp9LpAe1Lqy/fY/qCovCm0qnXZOBM=
 github.com/cpuguy83/go-md2man/v2 v2.0.3/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
@@ -22,6 +23,7 @@ github.com/pelletier/go-toml/v2 v2.1.0 h1:FnwAJ4oYMvbT/34k9zzHuZNrhlz48GB3/s6at6
 github.com/pelletier/go-toml/v2 v2.1.0/go.mod h1:tJU2Z3ZkXwnxa4DPO899bsyIoywizdUvyaeZurnPPDc=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/russross/blackfriday/v2 v2.1.0 h1:JIOH55/0cWyOuilr9/qlrm0BSXldqnqwMsf35Ld67mk=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/spf13/cobra v1.8.0 h1:7aJaZx1B85qltLMc546zn58BxxfZdR/W22ej9CFoEf0=
 github.com/spf13/cobra v1.8.0/go.mod h1:WXLWApfZ71AjXPya3WOlMsY9yMs7YeiHhFVlvLyhcho=

--- a/internal/command/man.go
+++ b/internal/command/man.go
@@ -1,0 +1,26 @@
+package command
+
+import (
+	"github.com/spf13/cobra"
+	"github.com/spf13/cobra/doc"
+)
+
+func manCommand(root *cobra.Command) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "man -o <dir>",
+		Short: "Generate manual pages for all dasel subcommands",
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return manRunE(cmd, root)
+		},
+	}
+
+	cmd.Flags().StringP("output-directory", "o", ".", "The directory in which man pages will be created")
+
+	return cmd
+}
+
+func manRunE(cmd *cobra.Command, root *cobra.Command) error {
+	outputDirectory, _ := cmd.Flags().GetString("output-directory")
+
+	return doc.GenManTree(root, nil, outputDirectory)
+}

--- a/internal/command/root.go
+++ b/internal/command/root.go
@@ -18,5 +18,8 @@ func NewRootCMD() *cobra.Command {
 		validateCommand(),
 	)
 
+	manCmd := manCommand(selectCmd)
+	selectCmd.AddCommand(manCmd)
+
 	return selectCmd
 }


### PR DESCRIPTION
This PR adds a new sucommand (`man`) that generates manpages for all dasel subcommands (including `man` itself). Closes #201.

This is the first implementation that came to mind, so it may not be exactly what you had in mind. Let me know if you want me to change anything.

I also wasn't sure if adding tests for this subcommand was worth the trouble. Let me know if you want me to implement them anyway.

Thanks!