### PR TITLE
if opening a file fails, specify whether it was for reading or for writing

### DIFF
--- a/internal/command/options.go
+++ b/internal/command/options.go
@@ -70,7 +70,7 @@ func (o *readOptions) rootValue(cmd *cobra.Command) (dasel.Value, error) {
 		} else {
 			f, err := os.Open(o.FilePath)
 			if err != nil {
-				return dasel.Value{}, fmt.Errorf("could not open file: %s: %w", o.FilePath, err)
+				return dasel.Value{}, fmt.Errorf("could not open file for reading: %s: %w", o.FilePath, err)
 			}
 			defer f.Close()
 			reader = f
@@ -177,7 +177,7 @@ func (o *writeOptions) writeValues(cmd *cobra.Command, readOptions *readOptions,
 		} else {
 			f, err := os.Create(o.FilePath)
 			if err != nil {
-				return fmt.Errorf("could not open file: %s: %w", o.FilePath, err)
+				return fmt.Errorf("could not open file for writing: %s: %w", o.FilePath, err)
 			}
 			defer f.Close()
 			writer = f


### PR DESCRIPTION
Hello, thanks for Dasel!

I stumbled upon this minor enhancement to a diagnostic message, so I went away with the PR without opening an issue before.

Assume a read-only file:

    touch foo.json
    chmod 400 foo.json

and the Dasel invocation:

    dasel put -f foo.json -r json -t string -v Frank 'name.first'

Before this commit, we would get:

    Error: could not open file: foo.json: open foo.json: permission denied

leaving the user confused.

Now instead we would get:

    Error: could not open file for writing: foo.json: open foo.json: permission denied
                               ^^^^^^^^^^^

helping the user to understand what is happening.