### PR TITLE
Don't include timestamp in generated manpages

### DIFF
--- a/internal/command/man.go
+++ b/internal/command/man.go
@@ -6,6 +6,10 @@ import (
 )
 
 func manCommand(root *cobra.Command) *cobra.Command {
+	// Do not include timestamp in generated man pages.
+	// See https://github.com/spf13/cobra/issues/142
+	root.DisableAutoGenTag = true
+
 	cmd := &cobra.Command{
 		Use:   "man -o <dir>",
 		Short: "Generate manual pages for all dasel subcommands",


### PR DESCRIPTION
This makes manpage generation reproducible. I found this problem using Debian's reproducible builds infrastructure.

```diff
--- old/dasel.1	2024-05-02 15:59:19.342436672 -0300
+++ new/dasel.1	2024-05-02 15:52:35.300986397 -0300
@@ -1,5 +1,5 @@
 .nh
-.TH "DASEL" "1" "May 2024" "Auto generated by spf13/cobra" ""
+.TH "DASEL" "1" "May 2024" "" ""
 
 .SH NAME
 .PP
@@ -73,8 +73,3 @@
 .SH SEE ALSO
 .PP
 \fBdasel-completion(1)\fP, \fBdasel-delete(1)\fP, \fBdasel-man(1)\fP, \fBdasel-put(1)\fP, \fBdasel-validate(1)\fP
-
-
-.SH HISTORY
-.PP
-2-May-2024 Auto generated by spf13/cobra
```