### PR TITLE
handle non-merge aliasing

### DIFF
--- a/dencoding/yaml_decoder.go
+++ b/dencoding/yaml_decoder.go
@@ -2,12 +2,13 @@ package dencoding
 
 import (
 	"fmt"
-	"github.com/tomwright/dasel/v2/util"
-	"gopkg.in/yaml.v3"
 	"io"
 	"reflect"
 	"strconv"
 	"time"
+
+	"github.com/tomwright/dasel/v2/util"
+	"gopkg.in/yaml.v3"
 )
 
 // YAMLDecoder wraps a standard yaml encoder to implement custom ordering logic.
@@ -64,6 +65,8 @@ func (decoder *YAMLDecoder) getNodeValue(node *yaml.Node) (any, error) {
 		return decoder.getSequenceNodeValue(node)
 	case yaml.ScalarNode:
 		return decoder.getScalarNodeValue(node)
+	case yaml.AliasNode:
+		return decoder.getNodeValue(node.Alias)
 	default:
 		return nil, fmt.Errorf("unhandled node kind: %v", node.Kind)
 	}

--- a/dencoding/yaml_decoder.go
+++ b/dencoding/yaml_decoder.go
@@ -2,13 +2,12 @@ package dencoding
 
 import (
 	"fmt"
+	"github.com/tomwright/dasel/v2/util"
+	"gopkg.in/yaml.v3"
 	"io"
 	"reflect"
 	"strconv"
 	"time"
-
-	"github.com/tomwright/dasel/v2/util"
-	"gopkg.in/yaml.v3"
 )
 
 // YAMLDecoder wraps a standard yaml encoder to implement custom ordering logic.

--- a/dencoding/yaml_decoder_test.go
+++ b/dencoding/yaml_decoder_test.go
@@ -98,12 +98,16 @@ key2: value6
 	})
 
 	t.Run("YamlAliases", func(t *testing.T) {
-		b := []byte(`foo: &foo
+		b := []byte(`foo: &foofoo
   bar: 1
-  baz: "baz"
+  baz: &baz "baz"
 spam:
   ham: "eggs"
-  <<: *foo
+  bar: 0
+  <<: *foofoo
+  baz: "bazbaz"
+
+baz: *baz
 `)
 
 		dec := dencoding.NewYAMLDecoder(bytes.NewReader(b))
@@ -121,16 +125,15 @@ spam:
 			got = append(got, v)
 		}
 
-		fooMap := dencoding.NewMap().
-			Set("bar", int64(1)).
-			Set("baz", "baz")
-		spamMap := dencoding.NewMap().
-			Set("ham", "eggs").
-			Set("foo", fooMap)
-
 		exp := dencoding.NewMap().
-			Set("foo", fooMap).
-			Set("spam", spamMap)
+			Set("foo", dencoding.NewMap().
+				Set("bar", int64(1)).
+				Set("baz", "baz")).
+			Set("spam", dencoding.NewMap().
+				Set("ham", "eggs").
+				Set("bar", int64(1)).
+				Set("baz", "bazbaz")).
+			Set("baz", "baz")
 
 		if len(got) != 1 {
 			t.Errorf("expected result len of %d, got %d", 1, len(got))

--- a/internal/command/select_test.go
+++ b/internal/command/select_test.go
@@ -254,21 +254,25 @@ octal: 8`)),
 
 	t.Run("Issue285 - YAML alias on read", runTest(
 		[]string{"-r", "yaml", "-w", "yaml"},
-		[]byte(`foo: &foo
+		[]byte(`foo: &foofoo
   bar: 1
-  baz: baz
+  baz: &baz "baz"
 spam:
-  ham: eggs
-  <<: *foo
+  ham: "eggs"
+  bar: 0
+  <<: *foofoo
+  baz: "bazbaz"
+
+baz: *baz
 `),
 		[]byte(`foo:
   bar: 1
   baz: baz
 spam:
   ham: eggs
-  foo:
-    bar: 1
-    baz: baz
+  bar: 1
+  baz: bazbaz
+baz: baz
 `),
 		nil,
 		nil,


### PR DESCRIPTION
@TomWright my patch in #415 is incorrect and is missing a piece:

1. Regular alias dereferencing, e.g. `foo: *bar` was not handled, only merging an alias into a map.
2. Merging an alias into a map is incorrect in #415 as it should only merge the children of the aliased map rather then the aliased map itself. For example,
    
    ```yaml
    foo: &foo
      bar: 1
      baz: "baz"
    
    spam:
      <<: *foo
    ```
    
    currently decodes into
    
    ```yaml
    foo: &foo
      bar: 1
      baz: "baz"
    
    spam:
      foo: foo
        bar: 1
        baz: "baz"
    ```
    
    but should decode into
    
    ```yaml
    foo: &foo
      bar: 1
      baz: "baz"
    
    spam:
      bar: 1
      baz: "baz"
    ```