### PR TITLE
Update install in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ brew install dasel
 ### Go Install
 
 ```sh
-go install github.com/TomWright/dasel/v3/cmd/dasel@latest
+go install github.com/tomwright/dasel/v3/cmd/dasel@latest
 ```
 
 ### Prebuilt Binaries


### PR DESCRIPTION
Use lowercase module name in Go install command.

This fixes the following install issue:
```sh
go: github.com/TomWright/dasel/v3/cmd/dasel@latest: version constraints conflict:
	github.com/TomWright/dasel/v3@v3.0.0-20250827120859-ca1aa067eff1: parsing go.mod:
	module declares its path as: github.com/tomwright/dasel/v3
	        but was required as: github.com/TomWright/dasel/v3
```