### PR TITLE
man: use SOURCE_DATE_EPOCH if defined

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- `dasel man` now generates a reproducible manpage based on [SOURCE_DATE_EPOCH](https://reproducible-builds.org/specs/source-date-epoch).
+
 ## [v3.8.0] - 2026-04-26
 
 ### Added

--- a/internal/cli/man.go
+++ b/internal/cli/man.go
@@ -3,6 +3,8 @@ package cli
 import (
 	"bytes"
 	"fmt"
+	"os"
+	"strconv"
 	"strings"
 	"text/template"
 	"time"
@@ -35,6 +37,24 @@ type manData struct {
 	QueryFlags  []manFlag
 }
 
+const dateFormat = "2006-01-02"
+
+func getReproducibleDate() (string, error) {
+	sourceDateEpochEnv, ok := os.LookupEnv("SOURCE_DATE_EPOCH")
+
+	// Fallback to current date if SOURCE_DATE_EPOCH is unset or empty.
+	if !ok || sourceDateEpochEnv == "" {
+		return time.Now().Format(dateFormat), nil
+	}
+
+	sde, err := strconv.ParseInt(sourceDateEpochEnv, 10, 64)
+	if err != nil {
+		return "", fmt.Errorf("invalid SOURCE_DATE_EPOCH: %q", sourceDateEpochEnv)
+	}
+
+	return time.Unix(sde, 0).UTC().Format(dateFormat), nil
+}
+
 func extractManData(k *kong.Kong) manData {
 	app := k.Model
 
@@ -42,7 +62,6 @@ func extractManData(k *kong.Kong) manData {
 		Name:        strings.ToUpper(app.Name),
 		Description: app.Help,
 		Version:     internal.Version,
-		Date:        time.Now().Format("2006-01-02"),
 	}
 
 	for _, flag := range app.Flags {
@@ -94,6 +113,12 @@ func extractManData(k *kong.Kong) manData {
 
 func (c *ManCmd) Run(ctx *Globals) error {
 	data := extractManData(ctx.Kong)
+
+	date, err := getReproducibleDate()
+	if err != nil {
+		return fmt.Errorf("error extracting man page data: %w", err)
+	}
+	data.Date = date
 
 	tmpl, err := template.New("man").Funcs(template.FuncMap{
 		"toLower": strings.ToLower,


### PR DESCRIPTION
This makes manpage generation reproducible. See https://reproducible-builds.org/specs/source-date-epoch.

Found on reproduce.debian.net: https://reproduce.debian.net/arm64/api/v1/builds/214379/artifacts/500068/diffoscope