### PR TITLE
Produce valid TOML for non-map root values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- TOML writer now wraps non-map root values (scalars, slices) in a single-key map (`value = ...`) so the output is valid TOML. Previously it emitted bare values which are not valid TOML at the document root.
+
 ## [v3.11.2] - 2026-06-27
 
 ### Security

--- a/go.mod
+++ b/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/goccy/go-json v0.10.6
 	github.com/google/go-cmp v0.7.0
 	github.com/hashicorp/hcl/v2 v2.24.0
-	github.com/pelletier/go-toml/v2 v2.2.5-0.20250826075308-a0e846496753
+	github.com/pelletier/go-toml/v2 v2.4.3
 	github.com/zclconf/go-cty v1.17.0
 	go.yaml.in/yaml/v4 v4.0.0-rc.3
 	gopkg.in/ini.v1 v1.67.0

--- a/go.sum
+++ b/go.sum
@@ -68,6 +68,8 @@ github.com/muesli/termenv v0.16.0 h1:S5AlUN9dENB57rsbnkPyfdGuWIlkmzJjbFf0Tf5FWUc
 github.com/muesli/termenv v0.16.0/go.mod h1:ZRfOIKPFDYQoDFF4Olj7/QJbW60Ol/kL1pU3VfY/Cnk=
 github.com/pelletier/go-toml/v2 v2.2.5-0.20250826075308-a0e846496753 h1:aTpyfgn3dz2npHl011BHQehdSavqjzhZdE6fJuJlO3A=
 github.com/pelletier/go-toml/v2 v2.2.5-0.20250826075308-a0e846496753/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
+github.com/pelletier/go-toml/v2 v2.4.3 h1:GTRvJQutkOSftxIFD5xw9aepkYNuPWmVJpffdDPYVpY=
+github.com/pelletier/go-toml/v2 v2.4.3/go.mod h1:2gIqNv+qfxSVS7cM2xJQKtLSTLUE9V8t9Stt+h56mCY=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rivo/uniseg v0.4.7 h1:WUdvkW8uEhrYfLC4ZzdpI2ztxP1I582+49Oc5Mq64VQ=

--- a/internal/cli/generic_test.go
+++ b/internal/cli/generic_test.go
@@ -178,7 +178,7 @@ sliceOfNumbers = [1, 2, 3, 4, 5]
 					out: []bytesWithFormat{
 						newStringWithFormat(json.JSON, `"world"`),
 						newStringWithFormat(yaml.YAML, `world`),
-						newStringWithFormat(toml.TOML, `'world'`),
+						newStringWithFormat(toml.TOML, `value = 'world'`),
 					},
 				}.run)
 				t.Run("int", testCases{
@@ -191,7 +191,7 @@ sliceOfNumbers = [1, 2, 3, 4, 5]
 					out: []bytesWithFormat{
 						newStringWithFormat(json.JSON, `123`),
 						newStringWithFormat(yaml.YAML, `123`),
-						newStringWithFormat(toml.TOML, `123`),
+						newStringWithFormat(toml.TOML, `value = 123`),
 					},
 				}.run)
 				t.Run("float", testCases{
@@ -204,7 +204,7 @@ sliceOfNumbers = [1, 2, 3, 4, 5]
 					out: []bytesWithFormat{
 						newStringWithFormat(json.JSON, `12.3`),
 						newStringWithFormat(yaml.YAML, `12.3`),
-						newStringWithFormat(toml.TOML, `12.3`),
+						newStringWithFormat(toml.TOML, `value = 12.3`),
 					},
 				}.run)
 				t.Run("bool", func(t *testing.T) {
@@ -217,7 +217,7 @@ sliceOfNumbers = [1, 2, 3, 4, 5]
 						out: []bytesWithFormat{
 							newStringWithFormat(json.JSON, `true`),
 							newStringWithFormat(yaml.YAML, `true`),
-							newStringWithFormat(toml.TOML, `true`),
+							newStringWithFormat(toml.TOML, `value = true`),
 						},
 					}.run)
 					t.Run("false", testCases{
@@ -229,7 +229,7 @@ sliceOfNumbers = [1, 2, 3, 4, 5]
 						out: []bytesWithFormat{
 							newStringWithFormat(json.JSON, `false`),
 							newStringWithFormat(yaml.YAML, `false`),
-							newStringWithFormat(toml.TOML, `false`),
+							newStringWithFormat(toml.TOML, `value = false`),
 						},
 					}.run)
 					t.Run("true string", testCases{
@@ -241,7 +241,7 @@ sliceOfNumbers = [1, 2, 3, 4, 5]
 						out: []bytesWithFormat{
 							newStringWithFormat(json.JSON, `"true"`),
 							newStringWithFormat(yaml.YAML, `"true"`),
-							newStringWithFormat(toml.TOML, `'true'`),
+							newStringWithFormat(toml.TOML, `value = 'true'`),
 						},
 					}.run)
 					t.Run("false string", testCases{
@@ -253,7 +253,7 @@ sliceOfNumbers = [1, 2, 3, 4, 5]
 						out: []bytesWithFormat{
 							newStringWithFormat(json.JSON, `"false"`),
 							newStringWithFormat(yaml.YAML, `"false"`),
-							newStringWithFormat(toml.TOML, `'false'`),
+							newStringWithFormat(toml.TOML, `value = 'false'`),
 						},
 					}.run)
 				})
@@ -297,7 +297,7 @@ boolFalse: false`)
 		out: []bytesWithFormat{
 			newStringWithFormat(json.JSON, `"world"`),
 			newStringWithFormat(yaml.YAML, `world`),
-			newStringWithFormat(toml.TOML, `'world'`),
+			newStringWithFormat(toml.TOML, `value = 'world'`),
 		},
 	}.run)
 
@@ -311,7 +311,7 @@ boolFalse: false`)
 		out: []bytesWithFormat{
 			newStringWithFormat(json.JSON, `123`),
 			newStringWithFormat(yaml.YAML, `123`),
-			newStringWithFormat(toml.TOML, `123`),
+			newStringWithFormat(toml.TOML, `value = 123`),
 		},
 	}.run)
 
@@ -325,7 +325,7 @@ boolFalse: false`)
 		out: []bytesWithFormat{
 			newStringWithFormat(json.JSON, `12.3`),
 			newStringWithFormat(yaml.YAML, `12.3`),
-			newStringWithFormat(toml.TOML, `12.3`),
+			newStringWithFormat(toml.TOML, `value = 12.3`),
 		},
 	}.run)
 
@@ -339,7 +339,7 @@ boolFalse: false`)
 		out: []bytesWithFormat{
 			newStringWithFormat(json.JSON, `true`),
 			newStringWithFormat(yaml.YAML, `true`),
-			newStringWithFormat(toml.TOML, `true`),
+			newStringWithFormat(toml.TOML, `value = true`),
 		},
 	}.run)
 
@@ -353,7 +353,7 @@ boolFalse: false`)
 		out: []bytesWithFormat{
 			newStringWithFormat(json.JSON, `false`),
 			newStringWithFormat(yaml.YAML, `false`),
-			newStringWithFormat(toml.TOML, `false`),
+			newStringWithFormat(toml.TOML, `value = false`),
 		},
 	}.run)
 

--- a/parsing/toml/toml_writer.go
+++ b/parsing/toml/toml_writer.go
@@ -47,12 +47,20 @@ func (j *tomlWriter) Write(value *model.Value) ([]byte, error) {
 		if err != nil {
 			return nil, fmt.Errorf("failed to convert non-map top-level value: %w", err)
 		}
+
+		var inner interface{}
+
 		// For nil/zero interface, ensure we pass nil interface rather than a typed zero.
 		if typ.Kind() == reflect.Interface && rv.IsZero() {
-			goValue = nil
+			inner = nil
 		} else {
-			goValue = rv.Interface()
+			inner = rv.Interface()
 		}
+
+		// go-toml requires a table at the document root; a bare scalar or
+		// array at the root is not valid TOML. Wrap non-map top-level values
+		// in a single-key map.
+		goValue = map[string]interface{}{"value": inner}
 	}
 
 	// We currently encode the top level value directly. We have little control over nested values.


### PR DESCRIPTION
A document like the one below (or anything that is not a key-value pair):

```
123
```

is not valid TOML. This PR fixes this by making it a key-value pair instead.

```
value = 123
```

Do note that this is a breaking change, but I guess this is fine since the previously emitted documents were just invalid.

I chose `value` here arbitrarily, it could be changed to another key. This fixes #550, and also bumps to-toml to the latest version.